### PR TITLE
Add requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,10 @@ setup(
     url='https://github.com/ollix/cclint',
     license='BSD',
     packages=packages,
+    install_requires=[
+        'colorama',
+        'cpplint'
+    ],
     scripts=['cclint/bin/cclint'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This will mean that users installing cclint with 'pip install cclint' will have the dependencies automatically installed
