### PR TITLE
Add cclint.exe on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,11 @@ setup(
     license='BSD',
     packages=packages,
     scripts=['cclint/bin/cclint'],
+    entry_points={
+        'console_scripts': [
+            'cclint = cclint:command.execute_from_command_line',
+        ],
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
This will make it easer for Windows users to use cclint. They will be able to run 'cclint test.py' instead of 'python path/to/cclint test.py'
