### PR TITLE
Use empty list as default value for cpplint._exclude if --exclude option is not specified

### DIFF
--- a/cclint/command.py
+++ b/cclint/command.py
@@ -158,7 +158,7 @@ def execute_from_command_line():
     update_cpplint_usage()
     options, cpplint_filenames = parse_arguments()
 
-    exclude_paths = [os.path.abspath(f) for f in cpplint._excludes]
+    exclude_paths = [os.path.abspath(f) for f in cpplint._excludes or []]
 
     # Determines the list of filenames to process.
     if options['expanddir'] == 'no':


### PR DESCRIPTION
It seems that cpplint._exclude option [is None](https://github.com/cpplint/cpplint/blob/master/cpplint.py#L633), when --exclude option [is not passed](https://github.com/cpplint/cpplint/blob/master/cpplint.py#L6374). Thus running cclint without --exclude option is not possible with the latest commits:

```
Traceback (most recent call last):
  File "/home/lx/work/mipt/problembook/.venv/bin/cclint", line 11, in <module>
    sys.exit(command.execute_from_command_line())
  File "/home/lx/work/mipt/problembook/.venv/lib/python3.6/site-packages/cclint/command.py", line 161, in execute_from_command_line
    exclude_paths = [os.path.abspath(f) for f in cpplint._excludes]
TypeError: 'NoneType' object is not iterable

```

This PR fixes issue. Actually patch should be applied to cpplint, but the project seems to be orphaned and out of sync with Google's upstream.